### PR TITLE
Add documentation URL

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ author_email = rayluo.mba@gmail.com
 url = https://github.com/rayluo/identity
 project_urls =
     Changelog = https://github.com/rayluo/identity/releases
+    Documentation = https://identity-library.readthedocs.io/
 keywords = identity, auth, authentication, authorization
 license = MIT
 classifiers =


### PR DESCRIPTION
It'd be nice if pypi.org showed a link to the documentation. I *think* this is how it's specified, but all the docs these days show pyproject.toml, not setup.cfg, so I'm not positive.