### PR TITLE
Obtain logout endpoint from OIDC Discovery

### DIFF
--- a/identity/version.py
+++ b/identity/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.0"  # Note: Perhaps update ReadTheDocs and README.md too?
+__version__ = "0.5.1"  # Note: Perhaps update ReadTheDocs and README.md too?

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ long_description_content_type = text/markdown
 python_requires = >=3.7
 install_requires =
     msal>=1.16,<2
-    # requests>=2.0.0,<3
+    requests>=2.0.0,<3
     # importlib; python_version == "2.6"
     # See also https://setuptools.readthedocs.io/en/latest/userguide/quickstart.html#dependency-management
 


### PR DESCRIPTION
This way, the logout functionality is expected to also work for Microsoft Entra external ID (CIAM), and probably B2C too.

You can test it by using [this Django sample](https://github.com/Azure-Samples/ms-identity-python-webapp-django) and [this Flask sample](https://github.com/Azure-Samples/ms-identity-python-webapp), and then manually upgrading the `identity` library by `pip install --force-reinstall git+https://github.com/rayluo/identity.git@logout`