### PR TITLE
flask.Auth.login: pass next_link to self._auth.log_in

### DIFF
--- a/identity/flask.py
+++ b/identity/flask.py
@@ -66,6 +66,7 @@ class Auth(WebFrameworkAuth):
             scopes=scopes,  # Have user consent to scopes (if any) during log-in
             redirect_uri=self._redirect_uri,
             prompt="select_account",  # Optional. More values defined in  https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
+            next_link=next_link,
             )
         if "error" in log_in_result:
             return self._render_auth_error(

--- a/identity/quart.py
+++ b/identity/quart.py
@@ -66,6 +66,7 @@ class Auth(WebFrameworkAuth):
             scopes=scopes,  # Have user consent to scopes (if any) during log-in
             redirect_uri=self._redirect_uri,
             prompt="select_account",  # Optional. More values defined in  https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
+            next_link=next_link,
             )
         if "error" in log_in_result:
             return await self._render_auth_error(


### PR DESCRIPTION
Fixes: rayluo#27

Previously, `flask.Auth.login` does not pass `next_link` to `self._auth.login`, so users who complete authentication are passed to `/`. This commit causes `flask.Auth.login` to pass `next_link` to `self._auth.login` so users could return to the page they are on, when they complete logging in.