### PR TITLE
Provide access to get_user()

### DIFF
--- a/identity/pallet.py
+++ b/identity/pallet.py
@@ -92,6 +92,9 @@ class PalletAuth(WebFrameworkAuth):
             ) if self._post_logout_view else self._request.url_root)
         )
 
+    def get_user(self):
+        return self._auth.get_user()
+        
     def login_required(  # Named after Django's login_required
         self,
         function=None,


### PR DESCRIPTION
Allow handlers to determine if a user is already logged in, without requiring a login. This allows for a welcome banner or a logout link to be displayed on a home page for signed in users without forcing all users to sign in.