### PR TITLE
Support Django 6.x by widening version constraint

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
 
 # NOTE: Settings of this section below this line should not need to be changed
 
@@ -58,9 +59,9 @@ all_for_docs =
     %(flask)s
     %(quart)s
 django =
-    # Since we currently still supports Python 3.7, we choose Django version accordingly.
-    # See https://docs.djangoproject.com/en/5.0/faq/install/#what-python-version-can-i-use-with-django
-    django>=3.2,<6
+    # Django 6.0 requires Python 3.12+, Django 5.x requires Python 3.10+
+    # See https://docs.djangoproject.com/en/6.0/faq/install/#what-python-version-can-i-use-with-django
+    django>=3.2,<7
 flask =
     flask
     # If Flask-Session is not maintained in future, Flask-Session2 should work as well


### PR DESCRIPTION
Fixes: rayluo#62

Django 6.0 was released in December 2024 (with 6.0.1 in January 2026, and 6.0.5 currently on PyPI). The constraint `django>=3.2,<6` prevents `pip install identity[django]` alongside Django 6+ — exactly the resolver error reported in #62.

After reviewing `identity/django.py`, this library only uses stable Django APIs that have no breaking changes in Django 6.0:

- `django.shortcuts.redirect`, `render`
- `django.urls.include`, `path`, `reverse`
- `request.session`, `request.GET`, `request.build_absolute_uri()`, `request.get_full_path()`

This PR widens the constraint to `django>=3.2,<7` (covering the 6.x line) and adds Python 3.13 to the classifiers (Django 6.0 requires Python 3.12+).

### Tested

Validated end-to-end with Django 6.0.5 in a fresh Python 3.12 venv:

1. `pip install "identity[django]"` resolved without conflict — Django 6.0.5 was selected.
2. `from identity.django import Auth` and all its methods load.
3. A minimal Django 6 project wiring `AUTH = Auth(...)` in `settings.py` and `settings.AUTH.urlpattern` in `urls.py` passes `python manage.py check` cleanly (0 issues).
4. URL resolution: `/login`, `/logout` and `/getAToken` correctly bind to `Auth.login`, `Auth.logout`, `Auth.auth_response`.
5. Both bundled templates (`identity/login.html`, `identity/auth_error.html`) load via Django's `APP_DIRS` loader and render with realistic context.

A parallel PR exists in the Azure-Samples mirror: Azure-Samples/ms-identity-python#3.

References:
- [Django 6.0 release notes](https://docs.djangoproject.com/en/6.0/releases/6.0/)
- [Django Python version support](https://docs.djangoproject.com/en/6.0/faq/install/#what-python-version-can-i-use-with-django)